### PR TITLE
Fix name of the "original" repeat style

### DIFF
--- a/lua/nvim-next/init.lua
+++ b/lua/nvim-next/init.lua
@@ -12,7 +12,7 @@ local function setup(config)
     config = vim.deepcopy(config or {})
     config = vim.tbl_deep_extend("force", {}, default_config, config)
     if config.default_mappings.enable then
-        if config.default_mappings.repeat_style == "orignal" then
+        if config.default_mappings.repeat_style == "original" then
             vim.keymap.set({ "n" }, ";", move.repeat_last_move, { desc = "nvim-next", noremap = true })
             vim.keymap.set({ "n" }, ',', move.repeat_last_move_opposite, { desc = "nvim-prev", noremap = true })
         elseif config.default_mappings.repeat_style == "directional" then


### PR DESCRIPTION
Hi @ghostbuster91, I noticed that the default `repeat_style` needs to be set to `orignal` due to a typo.

This is a one-liner to fix it!