### PR TITLE
Fix: use `unpack()` instead of `table.unpack`

### DIFF
--- a/lua/nvim-next/integrations/gitsigns.lua
+++ b/lua/nvim-next/integrations/gitsigns.lua
@@ -3,17 +3,17 @@ local move = require("nvim-next.move")
 return function(gs)
     local prev_wrapped = move.make_backward_repeatable_move(
         function(opts)
-            gs.prev_hunk(table.unpack(opts.args or {}))
+            gs.prev_hunk(unpack(opts.args or {}))
         end,
         function(opts)
-            gs.next_hunk(table.unpack(opts.args or {}))
+            gs.next_hunk(unpack(opts.args or {}))
         end)
     local next_wrapped = move.make_forward_repeatable_move(
         function(opts)
-            gs.next_hunk(table.unpack(opts.args or {}))
+            gs.next_hunk(unpack(opts.args or {}))
         end,
         function(opts)
-            gs.prev_hunk(table.unpack(opts.args or {}))
+            gs.prev_hunk(unpack(opts.args or {}))
         end
     )
     return {


### PR DESCRIPTION
I'm curious about why you can run this code in neovim, actually `table.unpack` is added in Lua 5.2, which is not supported by LuaJIT(support Lua 5.1 only), and LuaJIT is the official Lua interpreter of neovim.