### PR TITLE
Fix dot-repeat for builtin motions when used with a command

### DIFF
--- a/lua/nvim-next/builtins/functions.lua
+++ b/lua/nvim-next/builtins/functions.lua
@@ -85,6 +85,7 @@ local state = {
     repeating = nil
 }
 
+-- based on https://github.com/echasnovski/mini.nvim/blob/main/lua/mini/jump.lua
 M.expr_f = function()
     state.result = vim.fn.nr2char(vim.fn.getchar())
     return vim.api.nvim_replace_termcodes('v:<C-u>lua NvimNextFunctions.f()<CR>', true, true, true)

--- a/lua/nvim-next/builtins/functions.lua
+++ b/lua/nvim-next/builtins/functions.lua
@@ -78,19 +78,50 @@ local function builtin_find_prev(inclusive, char, repeating)
     return res
 end
 
+local state = {
+    forward = nil,
+    inclusive = nil,
+    result = nil,
+    repeating = nil
+}
+
+M.expr_f = function()
+    state.result = vim.fn.nr2char(vim.fn.getchar())
+    return vim.api.nvim_replace_termcodes('v:<C-u>lua NvimNextFunctions.f()<CR>', true, true, true)
+end
+
 M.f = function(opts)
+    opts = opts or state
     return builtin_find_next("inclusive", opts.result, opts.repeating)
 end
 
+M.expr_F = function()
+    state.result = vim.fn.nr2char(vim.fn.getchar())
+    return vim.api.nvim_replace_termcodes('v:<C-u>lua NvimNextFunctions.F()<CR>', true, true, true)
+end
+
 M.F = function(opts)
+    opts = opts or state
     return builtin_find_prev("inclusive", opts.result, opts.repeating)
 end
 
+M.expr_t = function()
+    state.result = vim.fn.nr2char(vim.fn.getchar())
+    return vim.api.nvim_replace_termcodes('v:<C-u>lua NvimNextFunctions.t()<CR>', true, true, true)
+end
+
 M.t = function(opts)
+    opts = opts or state
     return builtin_find_next(not "inclusive", opts.result, opts.repeating)
 end
 
+M.expr_T = function()
+    state.result = vim.fn.nr2char(vim.fn.getchar())
+    return vim.api.nvim_replace_termcodes('v:<C-u>lua NvimNextFunctions.T()<CR>', true, true, true)
+end
+
 M.T = function(opts)
+    opts = opts or state
     return builtin_find_prev(not "inclusive", opts.result, opts.repeating)
 end
 

--- a/lua/nvim-next/builtins/init.lua
+++ b/lua/nvim-next/builtins/init.lua
@@ -3,15 +3,56 @@ local move = require("nvim-next.move")
 
 return {
     f = {
-        key_next = "f",
-        key_prev = "F",
-        func_next = move.make_forward_repeatable_move(functions.f, functions.F),
-        func_prev = move.make_backward_repeatable_move(functions.F, functions.f)
+        ["f"] = {
+            {
+                mode = { "n", "v" },
+                func = move.make_forward_repeatable_move(functions.f, functions.F),
+                opts = { desc = "nvim-next f" }
+            },
+            {
+                mode = { "o" },
+                func = [[v:lua.NvimNextFunctions.expr_f()]],
+                opts = { desc = "nvim-next f", expr = true }
+            }
+        },
+        ["F"] = {
+            {
+                mode = { "n", "v" },
+                func = move.make_forward_repeatable_move(functions.F, functions.f),
+                opts = { desc = "nvim-next F" }
+            },
+            {
+                mode = { "o" },
+                func = [[v:lua.NvimNextFunctions.expr_F()]],
+                opts = { desc = "nvim-next F", expr = true }
+            }
+        },
     },
     t = {
-        key_next = "t",
-        key_prev = "T",
-        func_next = move.make_forward_repeatable_move(functions.t, functions.T),
-        func_prev = move.make_forward_repeatable_move(functions.T, functions.t)
+        ["t"] = {
+            {
+                mode = { "n", "v" },
+                func = move.make_forward_repeatable_move(functions.t, functions.T),
+                opts = { desc = "nvim-next t" }
+            },
+            {
+                mode = { "o" },
+                func = [[v:lua.NvimNextFunctions.expr_t()]],
+                opts = { desc = "nvim-next t", expr = true }
+            }
+        },
+        ["T"] = {
+            {
+                mode = { "n", "v" },
+                func = move.make_forward_repeatable_move(functions.T, functions.t),
+                opts = { desc = "nvim-next T" }
+            },
+            {
+                mode = { "o" },
+                -- func = functions.expr_T,
+                func = [[v:lua.NvimNextFunctions.expr_T()]],
+                opts = { desc = "nvim-next T", expr = true }
+            }
+        },
     },
 }

--- a/lua/nvim-next/init.lua
+++ b/lua/nvim-next/init.lua
@@ -1,4 +1,5 @@
 local move = require("nvim-next.move")
+local functions = require("nvim-next.builtins.functions")
 
 local default_config = {
     default_mappings = {
@@ -9,6 +10,7 @@ local default_config = {
 }
 
 local function setup(config)
+    _G.NvimNextFunctions = functions -- todo should be autoload?
     config = vim.deepcopy(config or {})
     config = vim.tbl_deep_extend("force", {}, default_config, config)
     if config.default_mappings.enable then
@@ -26,10 +28,14 @@ local function setup(config)
             )
         end
     end
-    for _, i in ipairs(config.items) do
-        vim.keymap.set({ "n", "x", "o" }, i.key_prev, i.func_prev, i.opts)
-        vim.keymap.set({ "n", "x", "o" }, i.key_next, i.func_next, i.opts)
+    for _, item in ipairs(config.items) do
+        for key, bindings in pairs(item) do
+            for _, binding in ipairs(bindings) do
+                vim.keymap.set(binding.mode, key, binding.func, binding.opts)
+            end
+        end
     end
+
     return move
 end
 


### PR DESCRIPTION
Fixes #14

TODO: 
- [ ] resolve todos
- [ ] fix `dfs` eating one char when there is no more `s` in the current line