### PR TITLE
Fix conditions for builtins

### DIFF
--- a/lua/nvim-next/builtins/functions.lua
+++ b/lua/nvim-next/builtins/functions.lua
@@ -3,40 +3,36 @@ local move = require("nvim-next.move")
 local M = {}
 
 M.builtin_f_expr = function()
-    vim.notify_once("nvim-next: map `builtin_T_expr` with `{expr=true}` instead.", vim.log.levels.WARN)
     move.last_move = {
         func = "f",
-        opts = { forward = true },
+        opts = {},
         additional_args = {},
     }
     return "f"
 end
 
 M.builtin_F_expr = function()
-    vim.notify_once("nvim-next: map `builtin_T_expr` with `{expr=true}` instead.", vim.log.levels.WARN)
     move.last_move = {
         func = "F",
-        opts = { forward = false },
+        opts = {},
         additional_args = {},
     }
     return "F"
 end
 
 M.builtin_t_expr = function()
-    vim.notify_once("nvim-next: map `builtin_T_expr` with `{expr=true}` instead.", vim.log.levels.WARN)
     move.last_move = {
         func = "t",
-        opts = { forward = true },
+        opts = {},
         additional_args = {},
     }
     return "t"
 end
 
 M.builtin_T_expr = function()
-    vim.notify_once("nvim-next: map `builtin_T_expr` with `{expr=true}` instead.", vim.log.levels.WARN)
     move.last_move = {
         func = "T",
-        opts = { forward = false },
+        opts = {},
         additional_args = {},
     }
     return "T"

--- a/lua/nvim-next/move/init.lua
+++ b/lua/nvim-next/move/init.lua
@@ -12,22 +12,16 @@ M.repeat_last_move = function(opts_ext)
         -- directly from the https://github.com/nvim-treesitter/nvim-treesitter-textobjects/pull/622
         -- all credits go to @kiyoon
         if M.last_move.func == "f" or M.last_move.func == "t" then
-            if opts.force_forward then
-                vim.cmd([[normal! ]] .. vim.v.count1 .. ";")
-            else
-                vim.cmd([[normal! ]] .. vim.v.count1 .. ",")
-            end
+            vim.cmd([[normal! ]] .. vim.v.count1 .. ";")
         elseif M.last_move.func == "F" or M.last_move.func == "T" then
-            if opts.force_forward then
+            if opts.directional then
                 vim.cmd([[normal! ]] .. vim.v.count1 .. ",")
             else
                 vim.cmd([[normal! ]] .. vim.v.count1 .. ";")
             end
         else
-            if opts.force_forward then
+            if opts.directional then
                 M.last_move.forward(opts)
-            elseif opts.force_backward then
-                M.last_move.backward(opts)
             else
                 M.last_move.func(opts)
             end
@@ -41,21 +35,15 @@ M.repeat_last_move_opposite = function(opts_ext)
         local opts = vim.tbl_deep_extend("force", {}, M.last_move.opts, opts_ext)
 
         if M.last_move.func == "f" or M.last_move.func == "t" then
-            if opts.force_forward then
-                vim.cmd([[normal! ]] .. vim.v.count1 .. ";")
-            else
-                vim.cmd([[normal! ]] .. vim.v.count1 .. ",")
-            end
+            vim.cmd([[normal! ]] .. vim.v.count1 .. ",")
         elseif M.last_move.func == "F" or M.last_move.func == "T" then
-            if opts.force_forward then
-                vim.cmd([[normal! ]] .. vim.v.count1 .. ",")
-            else
+            if opts.directional then
                 vim.cmd([[normal! ]] .. vim.v.count1 .. ";")
+            else
+                vim.cmd([[normal! ]] .. vim.v.count1 .. ",")
             end
         else
-            if opts.force_forward then
-                M.last_move.forward(opts)
-            elseif opts.force_backward then
+            if opts.directional then
                 M.last_move.backward(opts)
             else
                 M.last_move.opposite(opts)
@@ -66,13 +54,13 @@ end
 
 M.repeat_last_move_forward = function()
     if M.last_move then
-        M.repeat_last_move { force_forward = true }
+        M.repeat_last_move({ directional = true })
     end
 end
 
 M.repeat_last_move_opposite_backward = function()
     if M.last_move then
-        M.repeat_last_move_opposite { force_backward = true }
+        M.repeat_last_move_opposite({ directional = true })
     end
 end
 


### PR DESCRIPTION
This should fix the repeat behaviour for the `f`/`F`/`t`/`T` builtins (raised here: #24). As part of making this fix I have done some cleanup as well for logically unneeded conditions or arguments. Hopefully, this would make it easier to follow/debug the code.

This works fine on my local for the 4 builtins and custom mappings for both `original` and `directional` modes.

As a stretch I have also removed the seemingly (?) unneeded warning. As the warning was not behind any condition, nor could it be affected by any user config, I feel it should not be here. At least in the form it is now. Do let me know if there was any other idea behind it.

Let me know your thoughts.
Thanks!